### PR TITLE
🥅 有効な画像以外の場合にアラートが出るようにした (#149)

### DIFF
--- a/src/_components/features/sidebar/CreateExpenseDialog.tsx
+++ b/src/_components/features/sidebar/CreateExpenseDialog.tsx
@@ -221,7 +221,7 @@ export const CreateExpenseDialog: FC<CreateDialogProps> = ({
               アップロード
               <input
                 type="file"
-                accept="image/png,image/jpeg" // MINETypeを指定
+                accept="image/png,image/jpeg" // MIMETypeを指定
                 onChange={handleImageUpload}
                 width="100%"
                 style={{ display: "none" }}


### PR DESCRIPTION
## 概要
以下の画像ファイルのみをアップロードできるようにする
- 5MB 以下
  - ファイルサイズで確認
- コンテントタイプ：image/png、image/jpeg
  - inputタグで、拡張子の制限
  - マジックナンバーで確認

## 動作確認
1. png, jepg,jpg以外の拡張子がアップロードできない。

ファイルアップロード時の表示。pdfは選択できないようになっている。
<img width="388" height="301" alt="スクリーンショット 2025-09-04 23 38 44" src="https://github.com/user-attachments/assets/ca1a381b-7cbc-4838-8882-4d962c69fac7" />

2. 拡張子のみjpegに変更してもあ、アラートメッセージが出る。



https://github.com/user-attachments/assets/f14628d0-def0-4b9c-a636-85803c5f6e52




3. 5MB以上のファイルをアップロードできない


https://github.com/user-attachments/assets/560964e6-c445-48d2-9219-2b586410c8be



