### PR TITLE
🐛 レシート解析を行わないとレシートがアップロードされないバグの解消 (#158)

### DIFF
--- a/src/_components/features/sidebar/CreateExpenseDialog.tsx
+++ b/src/_components/features/sidebar/CreateExpenseDialog.tsx
@@ -276,17 +276,16 @@ export const CreateExpenseDialog: FC<CreateDialogProps> = ({
     if (isBusy) {
       return;
     }
-    // 作成されていない場合のみ画像を削除
-    if (fileName && !isExpenseCreated) {
-      await deleteReceiptImage(fileName);
-    }
+    handleClose();
 
     // 状態をリセット
     setIsExpenseCreated(false);
     setLoadingState("idle");
     setErrorMessage(null);
 
-    handleClose();
+    if (fileName && !isExpenseCreated) {
+      deleteReceiptImage(fileName);
+    }
   };
 
   return (

--- a/src/_components/features/sidebar/CreateExpenseDialog.tsx
+++ b/src/_components/features/sidebar/CreateExpenseDialog.tsx
@@ -20,6 +20,7 @@ import {
   formatAndCreateExpense,
   getReceiptDetail,
   uploadImageToS3,
+  deleteReceiptImage,
 } from "@/_components/features/sidebar/SidebarActions";
 import { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
 
@@ -200,7 +201,7 @@ export const CreateExpenseDialog: FC<CreateDialogProps> = ({
             );
           }
         }
-      } catch (error) {
+      } catch {
         setErrorMessage(
           "レシート解析中にエラーが発生しました。サポートまでお問い合わせください。"
         );
@@ -210,7 +211,10 @@ export const CreateExpenseDialog: FC<CreateDialogProps> = ({
     }
   };
 
-  const handleImageRemove = () => {
+  const handleImageRemove = async () => {
+    if (fileName) {
+      deleteReceiptImage(fileName);
+    }
     setSelectedImage(null);
     setFileName(null);
   };

--- a/src/_components/features/sidebar/CreateExpenseDialog.tsx
+++ b/src/_components/features/sidebar/CreateExpenseDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { FC, useState } from "react";
+import React, { FC, useState, useEffect } from "react";
 import {
   Dialog,
   DialogContent,
@@ -110,6 +110,11 @@ export const CreateExpenseDialog: FC<CreateDialogProps> = ({
   const [isCreateDisabled, setIsCreateDisabled] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [isAnalyzing, setIsAnalyzing] = useState(false);
+  const [isExpenseCreated, setIsExpenseCreated] = useState(false);
+
+  useEffect(() => {
+    handleDialogClose();
+  }, [isExpenseCreated]);
 
   const handleImageUpload = async (
     event: React.ChangeEvent<HTMLInputElement>
@@ -167,13 +172,11 @@ export const CreateExpenseDialog: FC<CreateDialogProps> = ({
         categoryId,
         fileName
       );
+      setIsExpenseCreated(true);
       router.push(pathname + "?date=" + selectedDate + "&update=true");
     } else {
-      // TODO: エラーの対応を考える
-      console.log("The selected values are invalid");
+      setErrorMessage("全ての必須項目を入力してください。");
     }
-
-    handleClose();
   };
 
   const handleAnalyze = async () => {
@@ -213,16 +216,30 @@ export const CreateExpenseDialog: FC<CreateDialogProps> = ({
 
   const handleImageRemove = async () => {
     if (fileName) {
-      deleteReceiptImage(fileName);
+      await deleteReceiptImage(fileName);
     }
     setSelectedImage(null);
     setFileName(null);
   };
 
+  const handleDialogClose = async () => {
+    // 作成されていない場合のみ画像を削除
+    if (fileName && !isExpenseCreated) {
+      console.log("イメージ削除中");
+      await deleteReceiptImage(fileName);
+    }
+
+    // 状態をリセット
+    setIsExpenseCreated(false);
+    setErrorMessage(null);
+
+    handleClose();
+  };
+
   return (
     <Dialog
       open={open}
-      onClose={handleClose}
+      onClose={handleDialogClose}
       sx={{
         "& .MuiDialog-paper": {
           right: "10%",

--- a/src/_components/features/sidebar/CreateExpenseDialog.tsx
+++ b/src/_components/features/sidebar/CreateExpenseDialog.tsx
@@ -19,6 +19,7 @@ import {
 import {
   formatAndCreateExpense,
   getReceiptDetail,
+  uploadImageToS3,
 } from "@/_components/features/sidebar/SidebarActions";
 import { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
 
@@ -136,8 +137,20 @@ export const CreateExpenseDialog: FC<CreateDialogProps> = ({
       const fileName = `${fileNameUUID}.${fileExtension}`;
       setFileName(fileName); // UUIDファイル名を保存
       const reader = new FileReader();
-      reader.onloadend = () => {
-        setSelectedImage(reader.result as string); // base64をstringでセット
+      reader.onloadend = async () => {
+        const base64Image = reader.result as string;
+        setSelectedImage(base64Image); // base64をstringでセット
+
+        // S3へのアップロードを試行
+        const uploadResult = await uploadImageToS3(fileName, base64Image);
+        if (!uploadResult.success) {
+          // アップロードに失敗した場合は画像をリセット
+          setSelectedImage(null);
+          setFileName(null);
+          setErrorMessage(
+            "画像のアップロードに失敗しました。もう一度お試しください。"
+          );
+        }
       };
       reader.readAsDataURL(file); // base64に置き換え
     }
@@ -168,7 +181,6 @@ export const CreateExpenseDialog: FC<CreateDialogProps> = ({
         setErrorMessage(null);
         setIsAnalyzing(true);
         const analyzedReceiptDateRes = await getReceiptDetail(
-          selectedImage,
           fileName,
           categories
         );

--- a/src/_components/features/sidebar/CreateExpenseDialog.tsx
+++ b/src/_components/features/sidebar/CreateExpenseDialog.tsx
@@ -37,6 +37,13 @@ type CreateDialogProps = {
 
 const MAX_SIZE_IN_BYTES = 5 * 1024 * 1024; // 5MB
 
+class ValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ValidationError";
+  }
+}
+
 const validateFileType = async (file: File): Promise<boolean> => {
   return new Promise((resolve) => {
     const reader = new FileReader();
@@ -142,19 +149,19 @@ export const CreateExpenseDialog: FC<CreateDialogProps> = ({
 
         // ファイルサイズチェック
         if (file.size > MAX_SIZE_IN_BYTES) {
-          setErrorMessage(
+          throw new ValidationError(
             `ファイルサイズが大きすぎます。${
               MAX_SIZE_IN_BYTES / (1024 * 1024)
             }MB以下のファイルを選択してください。`
           );
-          return;
         }
 
         // ファイルタイプチェック（マジックナンバーでの検証）
         const isValidFileType = await validateFileType(file);
         if (!isValidFileType) {
-          setErrorMessage("PNG または JPEG ファイルのみアップロード可能です。");
-          return;
+          throw new ValidationError(
+            "PNG または JPEG ファイルのみアップロード可能です。"
+          );
         }
         const fileNameUUID = crypto.randomUUID();
         const fileExtension = file.name.split(".").pop();
@@ -166,11 +173,11 @@ export const CreateExpenseDialog: FC<CreateDialogProps> = ({
             if (reader.result) {
               resolve(reader.result as string);
             } else {
-              reject(new Error("ファイル読み込みに失敗しました"));
+              reject(new Error("画像のアップロードに失敗しました。"));
             }
           };
           reader.onerror = () =>
-            reject(new Error("ファイル読み込みに失敗しました"));
+            reject(new Error("画像のアップロードに失敗しました。"));
           reader.readAsDataURL(file);
         });
 
@@ -179,15 +186,17 @@ export const CreateExpenseDialog: FC<CreateDialogProps> = ({
         if (!uploadResult.success) {
           // アップロードに失敗した場合は画像をリセット
           setFileName(null);
-          setErrorMessage(
-            "画像のアップロードに失敗しました。もう一度お試しください。"
-          );
-        } else {
-          // アップロード成功後に画像を表示
-          setSelectedImage(base64Image);
+          throw new Error("画像のアップロードに失敗しました。");
         }
-      } catch {
-        setErrorMessage("画像のアップロードに失敗しました。");
+
+        // アップロード成功後に画像を表示
+        setSelectedImage(base64Image);
+      } catch (error) {
+        if (error instanceof ValidationError) {
+          setErrorMessage(error.message); // 詳細なバリデーションエラーメッセージを表示
+        } else {
+          setErrorMessage("画像のアップロードに失敗しました。"); // 汎用メッセージ
+        }
       } finally {
         setLoadingState("idle");
       }

--- a/src/_components/features/sidebar/CreateExpenseDialog.tsx
+++ b/src/_components/features/sidebar/CreateExpenseDialog.tsx
@@ -109,9 +109,20 @@ export const CreateExpenseDialog: FC<CreateDialogProps> = ({
   } = expenseDetailUseState;
   const [isCreateDisabled, setIsCreateDisabled] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [isAnalyzing, setIsAnalyzing] = useState(false);
+  type LoadingState =
+    | "idle"
+    | "uploading"
+    | "analyzing"
+    | "creating"
+    | "deleting";
+  const [loadingState, setLoadingState] = useState<LoadingState>("idle");
   const [isExpenseCreated, setIsExpenseCreated] = useState(false);
-  const [isCreating, setIsCreating] = useState(false);
+
+  const isUploading = loadingState === "uploading";
+  const isAnalyzing = loadingState === "analyzing";
+  const isCreating = loadingState === "creating";
+  const isDeleting = loadingState === "deleting";
+  const isBusy = loadingState !== "idle";
 
   useEffect(() => {
     if (isExpenseCreated) {
@@ -125,50 +136,71 @@ export const CreateExpenseDialog: FC<CreateDialogProps> = ({
     const file = event.target.files?.[0];
 
     if (file) {
-      // ファイルサイズチェック
-      if (file.size > MAX_SIZE_IN_BYTES) {
-        setErrorMessage(
-          `ファイルサイズが大きすぎます。${
-            MAX_SIZE_IN_BYTES / (1024 * 1024)
-          }MB以下のファイルを選択してください。`
-        );
-        return;
-      }
+      try {
+        setLoadingState("uploading");
+        setErrorMessage(null);
 
-      // ファイルタイプチェック（マジックナンバーでの検証）
-      const isValidFileType = await validateFileType(file);
-      if (!isValidFileType) {
-        setErrorMessage("PNG または JPEG ファイルのみアップロード可能です。");
-        return;
-      }
-      const fileNameUUID = crypto.randomUUID();
-      const fileExtension = file.name.split(".").pop();
-      const fileName = `${fileNameUUID}.${fileExtension}`;
-      setFileName(fileName); // UUIDファイル名を保存
-      const reader = new FileReader();
-      reader.onloadend = async () => {
-        const base64Image = reader.result as string;
-        setSelectedImage(base64Image); // base64をstringでセット
+        // ファイルサイズチェック
+        if (file.size > MAX_SIZE_IN_BYTES) {
+          setErrorMessage(
+            `ファイルサイズが大きすぎます。${
+              MAX_SIZE_IN_BYTES / (1024 * 1024)
+            }MB以下のファイルを選択してください。`
+          );
+          return;
+        }
+
+        // ファイルタイプチェック（マジックナンバーでの検証）
+        const isValidFileType = await validateFileType(file);
+        if (!isValidFileType) {
+          setErrorMessage("PNG または JPEG ファイルのみアップロード可能です。");
+          return;
+        }
+        const fileNameUUID = crypto.randomUUID();
+        const fileExtension = file.name.split(".").pop();
+        const fileName = `${fileNameUUID}.${fileExtension}`;
+        setFileName(fileName); // UUIDファイル名を保存
+        const base64Image = await new Promise<string>((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onloadend = () => {
+            if (reader.result) {
+              resolve(reader.result as string);
+            } else {
+              reject(new Error("ファイル読み込みに失敗しました"));
+            }
+          };
+          reader.onerror = () =>
+            reject(new Error("ファイル読み込みに失敗しました"));
+          reader.readAsDataURL(file);
+        });
 
         // S3へのアップロードを試行
         const uploadResult = await uploadImageToS3(fileName, base64Image);
         if (!uploadResult.success) {
           // アップロードに失敗した場合は画像をリセット
-          setSelectedImage(null);
           setFileName(null);
           setErrorMessage(
             "画像のアップロードに失敗しました。もう一度お試しください。"
           );
+        } else {
+          // アップロード成功後に画像を表示
+          setSelectedImage(base64Image);
         }
-      };
-      reader.readAsDataURL(file); // base64に置き換え
+      } catch {
+        setErrorMessage("画像のアップロードに失敗しました。");
+      } finally {
+        setLoadingState("idle");
+      }
     }
+
+    // 同じファイルを再選択可能にするため、input値をクリア
+    event.target.value = "";
   };
 
   const handleCreateExpense = async () => {
     if (expenseDate && storeName && amount && categoryId) {
       try {
-        setIsCreating(true);
+        setLoadingState("creating");
         setErrorMessage(null);
 
         await formatAndCreateExpense(
@@ -182,10 +214,10 @@ export const CreateExpenseDialog: FC<CreateDialogProps> = ({
 
         setIsExpenseCreated(true);
         router.push(pathname + "?date=" + selectedDate + "&update=true");
-      } catch (error) {
+      } catch {
         setErrorMessage("支出の作成に失敗しました。もう一度お試しください。");
       } finally {
-        setIsCreating(false);
+        setLoadingState("idle");
       }
     } else {
       setErrorMessage("全ての必須項目を入力してください。");
@@ -196,7 +228,7 @@ export const CreateExpenseDialog: FC<CreateDialogProps> = ({
     if (selectedImage && fileName) {
       try {
         setErrorMessage(null);
-        setIsAnalyzing(true);
+        setLoadingState("analyzing");
         const analyzedReceiptDateRes = await getReceiptDetail(
           fileName,
           categories
@@ -222,33 +254,36 @@ export const CreateExpenseDialog: FC<CreateDialogProps> = ({
           "レシート解析中にエラーが発生しました。サポートまでお問い合わせください。"
         );
       } finally {
-        setIsAnalyzing(false);
+        setLoadingState("idle");
       }
     }
   };
 
   const handleImageRemove = async () => {
-    if (fileName) {
-      await deleteReceiptImage(fileName);
+    try {
+      setLoadingState("deleting");
+      if (fileName) {
+        await deleteReceiptImage(fileName);
+      }
+      setSelectedImage(null);
+      setFileName(null);
+    } finally {
+      setLoadingState("idle");
     }
-    setSelectedImage(null);
-    setFileName(null);
   };
 
   const handleDialogClose = async () => {
-    if (isCreating || isAnalyzing) {
-      // 作成中または解析中は閉じない
+    if (isBusy) {
       return;
     }
     // 作成されていない場合のみ画像を削除
     if (fileName && !isExpenseCreated) {
-      console.log("イメージ削除中");
       await deleteReceiptImage(fileName);
     }
 
     // 状態をリセット
     setIsExpenseCreated(false);
-    setIsCreating(false);
+    setLoadingState("idle");
     setErrorMessage(null);
 
     handleClose();
@@ -270,8 +305,8 @@ export const CreateExpenseDialog: FC<CreateDialogProps> = ({
         <Box display="flex" flexDirection="row" height={"100%"}>
           <ReceiptUpload
             selectedImage={selectedImage}
-            handleImageUpload={handleImageUpload}
             handleImageRemove={handleImageRemove}
+            disabled={isBusy}
           />
           <AddExpenseDetail
             categories={categories}
@@ -295,8 +330,9 @@ export const CreateExpenseDialog: FC<CreateDialogProps> = ({
               variant="contained"
               component="label"
               sx={{ fontWeight: "bold", marginRight: "24px" }}
+              disabled={isBusy}
             >
-              アップロード
+              {isUploading ? "アップロード中..." : "アップロード"}
               <input
                 type="file"
                 accept="image/png,image/jpeg" // MIMETypeを指定
@@ -310,7 +346,7 @@ export const CreateExpenseDialog: FC<CreateDialogProps> = ({
                 variant="contained"
                 sx={{ fontWeight: "bold" }}
                 onClick={handleAnalyze}
-                disabled={isAnalyzing}
+                disabled={isBusy}
               >
                 {isAnalyzing ? "解析中..." : "レシート解析"}
               </Button>
@@ -320,7 +356,7 @@ export const CreateExpenseDialog: FC<CreateDialogProps> = ({
             variant="contained"
             sx={{ fontWeight: "bold" }}
             onClick={handleCreateExpense}
-            disabled={isCreateDisabled || isCreating}
+            disabled={isCreateDisabled || isBusy}
           >
             {isCreating ? "作成中..." : "作成"}
           </Button>

--- a/src/_components/features/sidebar/CreateExpenseDialog.tsx
+++ b/src/_components/features/sidebar/CreateExpenseDialog.tsx
@@ -111,9 +111,12 @@ export const CreateExpenseDialog: FC<CreateDialogProps> = ({
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [isAnalyzing, setIsAnalyzing] = useState(false);
   const [isExpenseCreated, setIsExpenseCreated] = useState(false);
+  const [isCreating, setIsCreating] = useState(false);
 
   useEffect(() => {
-    handleDialogClose();
+    if (isExpenseCreated) {
+      handleDialogClose();
+    }
   }, [isExpenseCreated]);
 
   const handleImageUpload = async (
@@ -162,18 +165,28 @@ export const CreateExpenseDialog: FC<CreateDialogProps> = ({
     }
   };
 
-  const handleCreateExpense = () => {
+  const handleCreateExpense = async () => {
     if (expenseDate && storeName && amount && categoryId) {
-      formatAndCreateExpense(
-        userId,
-        expenseDate,
-        storeName,
-        amount,
-        categoryId,
-        fileName
-      );
-      setIsExpenseCreated(true);
-      router.push(pathname + "?date=" + selectedDate + "&update=true");
+      try {
+        setIsCreating(true);
+        setErrorMessage(null);
+
+        await formatAndCreateExpense(
+          userId,
+          expenseDate,
+          storeName,
+          amount,
+          categoryId,
+          fileName
+        );
+
+        setIsExpenseCreated(true);
+        router.push(pathname + "?date=" + selectedDate + "&update=true");
+      } catch (error) {
+        setErrorMessage("支出の作成に失敗しました。もう一度お試しください。");
+      } finally {
+        setIsCreating(false);
+      }
     } else {
       setErrorMessage("全ての必須項目を入力してください。");
     }
@@ -223,6 +236,10 @@ export const CreateExpenseDialog: FC<CreateDialogProps> = ({
   };
 
   const handleDialogClose = async () => {
+    if (isCreating || isAnalyzing) {
+      // 作成中または解析中は閉じない
+      return;
+    }
     // 作成されていない場合のみ画像を削除
     if (fileName && !isExpenseCreated) {
       console.log("イメージ削除中");
@@ -231,6 +248,7 @@ export const CreateExpenseDialog: FC<CreateDialogProps> = ({
 
     // 状態をリセット
     setIsExpenseCreated(false);
+    setIsCreating(false);
     setErrorMessage(null);
 
     handleClose();
@@ -302,9 +320,9 @@ export const CreateExpenseDialog: FC<CreateDialogProps> = ({
             variant="contained"
             sx={{ fontWeight: "bold" }}
             onClick={handleCreateExpense}
-            disabled={isCreateDisabled}
+            disabled={isCreateDisabled || isCreating}
           >
-            作成
+            {isCreating ? "作成中..." : "作成"}
           </Button>
         </Box>
       </DialogActions>

--- a/src/_components/features/sidebar/ReceiptUpload.tsx
+++ b/src/_components/features/sidebar/ReceiptUpload.tsx
@@ -4,13 +4,14 @@ import CloseIcon from "@mui/icons-material/Close";
 
 type ReceiptUploadProps = {
   selectedImage: string | null;
-  handleImageUpload: (event: React.ChangeEvent<HTMLInputElement>) => void;
   handleImageRemove: () => void;
+  disabled?: boolean;
 };
 
 export const ReceiptUpload: FC<ReceiptUploadProps> = ({
   selectedImage,
   handleImageRemove,
+  disabled = false,
 }) => {
   return (
     <Box
@@ -41,6 +42,7 @@ export const ReceiptUpload: FC<ReceiptUploadProps> = ({
           </Avatar>
           <IconButton
             onClick={handleImageRemove}
+            disabled={disabled}
             sx={{
               position: "absolute",
               top: 1,

--- a/src/_components/features/sidebar/SidebarActions.ts
+++ b/src/_components/features/sidebar/SidebarActions.ts
@@ -1,6 +1,9 @@
 "use server";
 
-import { AnalyzeResult } from "@/_components/features/sidebar/type";
+import {
+  AnalyzeResult,
+  UploadResult,
+} from "@/_components/features/sidebar/type";
 import { formatStrDate } from "@/utils/time";
 import { createExpense } from "@/lib/db";
 import { uploadFileToS3, generatePreSignedURL } from "@/lib/s3";
@@ -8,15 +11,25 @@ import { getReceiptDetailFromModel } from "@/utils/analyzeReceipt";
 import { Category } from "@/types";
 import { ReceiptAnalysisError } from "@/constants/errors";
 
+export const uploadImageToS3 = async (
+  fileName: string,
+  selectedImage: string
+): Promise<UploadResult> => {
+  try {
+    const putPreSignedURL = await generatePreSignedURL(fileName, "put");
+    await uploadFileToS3(selectedImage, putPreSignedURL);
+    return { success: true };
+  } catch (error) {
+    console.error("S3への画像をアップロードに失敗しました:", error);
+    return { success: false };
+  }
+};
+
 export const getReceiptDetail = async (
-  selectedImage: string,
   fileName: string,
   categories: Category[]
 ): Promise<AnalyzeResult> => {
   try {
-    const putPreSignedURL = await generatePreSignedURL(fileName, "put");
-    await uploadFileToS3(selectedImage, putPreSignedURL);
-
     const receiptDetail = await getReceiptDetailFromModel(fileName);
 
     // 全ての項目がnullの場合のチェック

--- a/src/_components/features/sidebar/SidebarActions.ts
+++ b/src/_components/features/sidebar/SidebarActions.ts
@@ -6,7 +6,11 @@ import {
 } from "@/_components/features/sidebar/type";
 import { formatStrDate } from "@/utils/time";
 import { createExpense } from "@/lib/db";
-import { uploadFileToS3, generatePreSignedURL } from "@/lib/s3";
+import {
+  uploadFileToS3,
+  generatePreSignedURL,
+  deleteFileFromS3,
+} from "@/lib/s3";
 import { getReceiptDetailFromModel } from "@/utils/analyzeReceipt";
 import { Category } from "@/types";
 import { ReceiptAnalysisError } from "@/constants/errors";
@@ -83,5 +87,13 @@ export const formatAndCreateExpense = async (
     await createExpense(userId, amount, storeName, date, categoryId, fileName);
   } catch (error) {
     throw error;
+  }
+};
+
+export const deleteReceiptImage = async (fileName: string) => {
+  try {
+    await deleteFileFromS3(fileName);
+  } catch (error) {
+    console.error("S3からの画像削除に失敗しました:", error);
   }
 };

--- a/src/_components/features/sidebar/type.ts
+++ b/src/_components/features/sidebar/type.ts
@@ -21,6 +21,10 @@ export type AnalyzeResult =
       error: string;
     };
 
+export type UploadResult = {
+  success: boolean;
+};
+
 export type ExpenseDetail = {
   expenseDate: Date;
   setExpenseDate: React.Dispatch<React.SetStateAction<Date>>;

--- a/src/lib/s3.ts
+++ b/src/lib/s3.ts
@@ -4,6 +4,7 @@ import {
   S3Client,
   PutObjectCommand,
   GetObjectCommand,
+  DeleteObjectCommand,
 } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 
@@ -79,4 +80,9 @@ export const uploadFileToS3 = async (
   if (!response.ok) {
     throw new Error("S3へのアップロードに失敗しました");
   }
+};
+
+export const deleteFileFromS3 = async (fileName: string) => {
+  const bucketParams = { Bucket: BUCKET_NAME, Key: fileName };
+  await s3.send(new DeleteObjectCommand(bucketParams));
 };


### PR DESCRIPTION
## 概要

レシート解析をしなければ、レシートがアップロードされず、作成された出費を見てもレシートが登録されていない状況だった。

そのため、
- レシートをS3にアップロードするトリガーをアップロードボタンにし、解析ボタンではレシートアップロードを行わないようにした。
- 出費作成ダイアログで❌を押された際に、レシートをS3から削除するようにした。

## 補足
- レシートの削除はバージョニングなしの完全削除としている。
- ([理由](https://github.com/ogaogs/receipt-scanner/issues/158#issuecomment-3289085388))
- レシート削除が失敗してもエラーは表示しないようにした。([理由](https://github.com/ogaogs/receipt-scanner/issues/158#issuecomment-3289121486))

## 動作確認
1. レシート画像あり
    1. 解析を押さずに作成し、作成された出費にレシート画像が含まれることを確認した。
    2. 解析を実行し出費を作成し、作成された出費にレシート画像が含まれることを確認した。
3. レシート画像なし
    1. レシートを登録せずに、出費を追加した際に、作成された出費にレシートなしの出費が作成されることを確認した。
3. ❌を押下すると、レシートが削除されることを確認した

closes #158